### PR TITLE
Fix pylint issues

### DIFF
--- a/edx_sga/__init__.py
+++ b/edx_sga/__init__.py
@@ -1,1 +1,5 @@
+"""
+Module for StaffGradedAssignmentXBlock.
+"""
+
 from .sga import StaffGradedAssignmentXBlock

--- a/edx_sga/management/__init__.py
+++ b/edx_sga/management/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-docstring

--- a/edx_sga/management/commands/__init__.py
+++ b/edx_sga/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-docstring

--- a/edx_sga/management/commands/sga_migrate_submissions.py
+++ b/edx_sga/management/commands/sga_migrate_submissions.py
@@ -1,3 +1,8 @@
+"""
+Django command which migrates existing SGA submissions for a course from all
+old SGA implementation before v0.4.0 to newer version that uses the
+'submissions' application.
+"""
 import json
 
 from django.core.management.base import BaseCommand, CommandError
@@ -27,8 +32,10 @@ class Command(BaseCommand):
         course = get_course_by_id(course_key)
 
         student_modules = StudentModule.objects.filter(
-            course_id=course.id).filter(
-            module_state_key__contains='edx_sga')
+            course_id=course.id
+        ).filter(
+            module_state_key__contains='edx_sga'
+        )
 
         blocks = {}
         for student_module in student_modules:


### PR DESCRIPTION
**Problem statement**

There are several pylint violations creeping in here. We should try and resolve them. Helpful command to show them in devstack: PYTHONPATH=lms:lms/djangoapps:lms/lib:common/djangoapps:common/lib pylint --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" edx_sga | tee /edx/app/edxapp/edx-platform/reports/lms/pylint.report

**What I did**
Fixed all possible pylint warnings and errosr. Their are  still some warnings but these warnings are seem to be in valid  for example frame work related issue i.e request param is not used, fragment param is not use , xyx has no attribute id etc
